### PR TITLE
feat : nft 아이템 조회 api 연동

### DIFF
--- a/src/api/blockchainAPI.ts
+++ b/src/api/blockchainAPI.ts
@@ -56,3 +56,25 @@ export const geWalletAdress = async (): Promise<any> => {
       return null;
     }
   };
+
+  export const getNftItems = async (): Promise<any> => {
+    try {
+      const response = await instance.get('/block-chain/nfts');
+      console.log('NFT 아이템 전체 조회:', response.data);
+  
+      if (response.status === 200) {
+        return response.data.data; 
+      } else if (response.status === 500) {
+        Alert.alert('서버 오류', '서버와 통신하는 중 오류가 발생했습니다.');
+      }
+    } catch (error) {
+      const err = error as Error;
+      console.error('NFT 아이템 조회 실패:', error);
+  
+      Alert.alert(
+        'NFT 아이템 조회 실패',
+        err.message || 'NFT 아이템을 조회하는 중 오류가 발생했습니다.',
+      );
+      return null;
+    }
+  };

--- a/src/components/UnivItem.tsx
+++ b/src/components/UnivItem.tsx
@@ -3,8 +3,8 @@ import {View, Text, Image, StyleSheet, TouchableOpacity} from 'react-native';
 import GetItemModal from '../modal/GetItemModal';
 
 type UnivItemProps = {
-  universityUrl: any;
-  tokenURI: any;
+  universityUrl: string;
+  tokenURI: string;
   universityName: string;
   tokenPrice: number;
   tokenId: any;
@@ -24,10 +24,12 @@ const UnivItem: React.FC<UnivItemProps> = ({universityUrl, tokenURI, universityN
   return (
     <>
       <TouchableOpacity style={styles.container} onPress={onPressModalOpen}>
-        <Image source={universityUrl} style={styles.mascot} />
+        <View style={styles.imageWrapper}>
+          <Image source={{uri: tokenURI}} style={styles.mascot} /> 
+        </View>
 
         <View style={styles.univContainer}>
-          <Image source={tokenURI} style={styles.logo} />
+        <Image source={{uri: universityUrl}} style={styles.logo}/>
           <Text style={[styles.name, {marginLeft: 10}]}>{universityName}</Text>
         </View>
 
@@ -48,7 +50,7 @@ const UnivItem: React.FC<UnivItemProps> = ({universityUrl, tokenURI, universityN
 
 const styles = StyleSheet.create({
   tokenId: {
-    fontSize: 14,
+    fontSize: 13,
     backgroundColor: '#EFF3FE', 
     color: '#739DF5', 
     paddingHorizontal: 8, 
@@ -56,7 +58,16 @@ const styles = StyleSheet.create({
     borderRadius: 5, 
     fontWeight: 'bold', 
     top: 20, 
-    right: 37, 
+    right: 40, 
+  },
+  imageWrapper: {
+    borderWidth: 0.8,              
+    borderColor: '#D9D9D9',      
+    borderRadius: 20,             
+    padding: 8, 
+    justifyContent: 'center',     
+    alignItems: 'center',                
+    marginLeft: 30,
   },
   container: {
     flexDirection: 'row',
@@ -70,7 +81,6 @@ const styles = StyleSheet.create({
     flex: 1,
     flexDirection: 'row',
     justifyContent: 'space-between',
-    marginLeft: 15,
     top: -10,
   },
   msg: {
@@ -79,16 +89,20 @@ const styles = StyleSheet.create({
     position: 'absolute',
   },
   mascot: {
+    width: 50,
+    height: 50,
     resizeMode: 'contain',
-    marginLeft: 15,
   },
   logo: {
+    width: 28,
+    height: 28,
+    top: -5,
     resizeMode: 'contain',
     marginLeft: 25,
   },
   name: {
     width : 70,
-    fontSize: 16,
+    fontSize: 14,
     color: 'black',
     fontWeight: 'bold',
   },
@@ -98,7 +112,8 @@ const styles = StyleSheet.create({
   rd: {
     color: 'black',
     fontWeight: 'bold',
-    left: 40,
+    left: 38,
+    fontSize: 12,
   },
   rdImg: {
     marginLeft: 50,

--- a/src/components/UnivItem.tsx
+++ b/src/components/UnivItem.tsx
@@ -3,13 +3,14 @@ import {View, Text, Image, StyleSheet, TouchableOpacity} from 'react-native';
 import GetItemModal from '../modal/GetItemModal';
 
 type UnivItemProps = {
-  mascot: any;
-  logo: any;
-  name: string;
-  rd: number;
+  universityUrl: any;
+  tokenURI: any;
+  universityName: string;
+  tokenPrice: number;
+  tokenId: any;
 };
 
-const UnivItem: React.FC<UnivItemProps> = ({mascot, logo, name, rd}) => {
+const UnivItem: React.FC<UnivItemProps> = ({universityUrl, tokenURI, universityName, tokenPrice, tokenId}) => {
   const [isModalVisible, setIsModalVisible] = useState<boolean>(false);
 
   const onPressModalOpen = () => {
@@ -23,16 +24,20 @@ const UnivItem: React.FC<UnivItemProps> = ({mascot, logo, name, rd}) => {
   return (
     <>
       <TouchableOpacity style={styles.container} onPress={onPressModalOpen}>
-        <Image source={mascot} style={styles.mascot} />
+        <Image source={universityUrl} style={styles.mascot} />
 
         <View style={styles.univContainer}>
-          <Image source={logo} style={styles.logo} />
-          <Text style={[styles.name, {marginLeft: 10}]}>{name}</Text>
+          <Image source={tokenURI} style={styles.logo} />
+          <Text style={[styles.name, {marginLeft: 10}]}>{universityName}</Text>
+        </View>
+
+        <View>
+        <Text style={styles.tokenId}>#{tokenId}</Text>
         </View>
 
         <Image source={require('../../assets/rd.png')} style={styles.rdImg} />
         <View style={styles.rdContainer}>
-          <Text style={styles.rd}>{rd}</Text>
+          <Text style={styles.rd}>{tokenPrice}</Text>
         </View>
       </TouchableOpacity>
 
@@ -42,6 +47,17 @@ const UnivItem: React.FC<UnivItemProps> = ({mascot, logo, name, rd}) => {
 };
 
 const styles = StyleSheet.create({
+  tokenId: {
+    fontSize: 14,
+    backgroundColor: '#EFF3FE', 
+    color: '#739DF5', 
+    paddingHorizontal: 8, 
+    paddingVertical: 2,
+    borderRadius: 5, 
+    fontWeight: 'bold', 
+    top: 20, 
+    right: 37, 
+  },
   container: {
     flexDirection: 'row',
     alignItems: 'center',
@@ -55,6 +71,7 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     justifyContent: 'space-between',
     marginLeft: 15,
+    top: -10,
   },
   msg: {
     resizeMode: 'cover',
@@ -70,12 +87,13 @@ const styles = StyleSheet.create({
     marginLeft: 25,
   },
   name: {
+    width : 70,
     fontSize: 16,
     color: 'black',
     fontWeight: 'bold',
   },
   rdContainer: {
-    width: 100, // 시작점 통일
+    width: 100,
   },
   rd: {
     color: 'black',
@@ -87,6 +105,7 @@ const styles = StyleSheet.create({
     left: 30,
     resizeMode: 'contain',
   },
+  
 });
 
 export default UnivItem;

--- a/src/components/UnivList.tsx
+++ b/src/components/UnivList.tsx
@@ -4,28 +4,32 @@ import UnivItem from './UnivItem';
 
 const mockData = [
   {
-    mascot: require('../../assets/m1.png'),
-    logo: require('../../assets/l1.png'),
-    name: '중앙대학교',
-    rd: 130.25,
+    universityUrl: require('../../assets/m1.png'),
+    tokenURI: require('../../assets/l1.png'), // 학교 로고
+    universityName: '중앙대학교',
+    tokenPrice: 130.25,
+    tokenId: 0,
   },
   {
-    mascot: require('../../assets/m2.png'),
-    logo: require('../../assets/l2.png'),
-    name: '고려대학교',
-    rd: 921.0,
+    universityUrl: require('../../assets/m2.png'),
+    tokenURI: require('../../assets/l2.png'),
+    universityName: '고려대학교',
+    tokenPrice: 921.0,
+    tokenId: 0,
   },
   {
-    mascot: require('../../assets/m3.png'),
-    logo: require('../../assets/l3.png'),
-    name: '연세대학교',
-    rd: 1204.6,
+    universityUrl: require('../../assets/m3.png'),
+    tokenURI: require('../../assets/l3.png'),
+    universityName: '연세대학교',
+    tokenPrice: 1204.6,
+    tokenId: 0,
   },
   {
-    mascot: require('../../assets/m4.png'),
-    logo: require('../../assets/l4.png'),
-    name: '건국대학교',
-    rd: 269.2,
+    universityUrl: require('../../assets/m4.png'),
+    tokenURI: require('../../assets/l4.png'),
+    universityName: '건국대학교',
+    tokenPrice: 269.2,
+    tokenId: 0,
   },
 ];
 
@@ -37,10 +41,11 @@ const UnivList: React.FC = () => {
         data={mockData}
         renderItem={({item}) => (
           <UnivItem
-            mascot={item.mascot}
-            logo={item.logo}
-            name={item.name}
-            rd={item.rd}
+            universityUrl={item.universityUrl}
+            tokenURI={item.tokenURI}
+            universityName={item.universityName}
+            tokenPrice={item.tokenPrice}
+            tokenId={item.tokenId}
           />
         )}
         keyExtractor={(item, index) => index.toString()}
@@ -59,7 +64,7 @@ const styles = StyleSheet.create({
     resizeMode: 'cover',
     width: '102%',
     position: 'absolute',
-    top: 290,
+    top: 300,
   },
 });
 

--- a/src/components/UnivList.tsx
+++ b/src/components/UnivList.tsx
@@ -1,44 +1,28 @@
-import React from 'react';
+import React, {useState, useEffect} from 'react';
 import {Image, StyleSheet, FlatList} from 'react-native';
 import UnivItem from './UnivItem';
-
-const mockData = [
-  {
-    universityUrl: require('../../assets/m1.png'),
-    tokenURI: require('../../assets/l1.png'), // 학교 로고
-    universityName: '중앙대학교',
-    tokenPrice: 130.25,
-    tokenId: 0,
-  },
-  {
-    universityUrl: require('../../assets/m2.png'),
-    tokenURI: require('../../assets/l2.png'),
-    universityName: '고려대학교',
-    tokenPrice: 921.0,
-    tokenId: 0,
-  },
-  {
-    universityUrl: require('../../assets/m3.png'),
-    tokenURI: require('../../assets/l3.png'),
-    universityName: '연세대학교',
-    tokenPrice: 1204.6,
-    tokenId: 0,
-  },
-  {
-    universityUrl: require('../../assets/m4.png'),
-    tokenURI: require('../../assets/l4.png'),
-    universityName: '건국대학교',
-    tokenPrice: 269.2,
-    tokenId: 0,
-  },
-];
+import { getNftItems } from '../api/blockchainAPI';
 
 const UnivList: React.FC = () => {
+  const [nftItems, setNftItems] = useState<any[]>([]);
+
+  useEffect(() => {
+    const handleNftItems = async () => {
+      const items = await getNftItems();
+      //console.log('NFT Items:', items); 
+      if (items) {
+        setNftItems(items);
+      }
+    };
+    
+    handleNftItems();
+  }, []);
+
   return (
     <>
       <Image source={require('../../assets/nftMsg.png')} style={styles.msg} />
       <FlatList
-        data={mockData}
+        data={nftItems}
         renderItem={({item}) => (
           <UnivItem
             universityUrl={item.universityUrl}

--- a/src/screens/NFT/Nft.tsx
+++ b/src/screens/NFT/Nft.tsx
@@ -99,15 +99,14 @@ const styles = StyleSheet.create({
     backgroundColor: '#fff',
   },
   banner: {
-    // resizeMode: 'cover',
+    resizeMode: 'cover',
     top: 0,
     width: 393,
     height: 220,
   },
   addressButton: {
-    top: -100,
-    width: 45,
-    height: 45,
+    top: -130,
+    width: 50,
   },
   msg: {
     resizeMode: 'cover',


### PR DESCRIPTION
## 이슈 넘버

- close #44
<!-- # 뒤에 이슈넘버를 써서 이슈를 닫아주세요 -->

## 구현 사항

<!-- 실제로 변경한 사항을 설명해주세요.-->

- [x] nft 아이템 조회 api 연동
- [x] nft 아이템 내 연동된 변수명 명세서에 맞춰서 통일
- [x] 이미지 파일 테두리 추가 및 배치 수정
- [x] tokenID UI 추가

## Need Review
사소한 사항이지만 이미지 컴포넌트를 연동 후 url로 받아올 때 기존에 width, height를 StyleSheet에 명시해 두지 않아서 이미지가 안뜨는 문제가 있었다.
React Native의 Image 컴포넌트는 width와 height가 명확히 지정되지 않으면 이미지를 표시하지 않는 경우가 많으므로 이를 명시해줘야 한다.
로컬에서 임의로 png로 띄울때는 문제가 없었어서 이를 파악하는데 조금 걸렸다..

## 📸 스크린샷

<!-- 팀원들이 이해하기 쉽도록 스크린샷을 첨부해주세요. -->

<img width="293" alt="image" src="https://github.com/user-attachments/assets/bbd3c62e-c10d-4a8e-bb7d-b166443e75a8">

